### PR TITLE
Use correct architecture

### DIFF
--- a/playbooks/docker.yml
+++ b/playbooks/docker.yml
@@ -17,9 +17,12 @@
       apt_key:
         url: https://download.docker.com/linux/ubuntu/gpg
         keyring: /usr/share/keyrings/docker-archive-keyring.gpg
+    - name: Get dpkg architecture
+      command: dpkg --print-architecture
+      register: dpkg_arch
     - name: Add Docker apt repository
       apt_repository:
-        repo: deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu focal stable
+        repo: deb [arch={{ dpkg_arch.stdout }} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu focal stable
     - name: Install official docker and containerd
       apt:
         name: "{{ package }}"


### PR DESCRIPTION
Not tested in different architectures but this is the only place architecture is used