### PR TITLE
Fix node untaint check not working

### DIFF
--- a/playbooks/kubernetes.yml
+++ b/playbooks/kubernetes.yml
@@ -60,11 +60,11 @@
 - hosts: all
   tasks:
     - name: Check node master
-      command: kubectl get nodes --selector=node-role.kubernetes.io/master
+      command: kubectl get nodes --selector=node-role.kubernetes.io/master -ojsonpath --template='{.items[].spec.taints}'
       register: kube_node_master
     - name: Untaint node
       command: kubectl taint nodes --all node-role.kubernetes.io/master-
-      when: kube_node_master.stdout.find('master') == -1
+      when: kube_node_master.stdout.find('NoSchedule') != -1
     - name: Check Flannel
       command: kubectl -nkube-system get daemonset
       register: kube_flannel


### PR DESCRIPTION
`kubectl get nodes --selector=node-role.kubernetes.io/master` was always returning the master node. we need to check if the node is tainted